### PR TITLE
Add "no_color": True to option

### DIFF
--- a/nrkdl/nrkdl.py
+++ b/nrkdl/nrkdl.py
@@ -246,6 +246,7 @@ def main():
             "quiet": True,
             "skip_download": False,
             "no_warnings": True,
+            "no_color": True,
             "progress_hooks": [progress_hooks],
             "logger": logger(),
             "postprocessors": [],


### PR DESCRIPTION
current ytdl outputs ANSI color codes, breaking the progress parsing. this suppresses it.